### PR TITLE
Destructor fixes

### DIFF
--- a/src/librfnm.cpp
+++ b/src/librfnm.cpp
@@ -820,9 +820,11 @@ MSDLL librfnm::~librfnm() {
 
     if (usb_handle) {
         if (usb_handle->primary) {
+            libusb_release_interface(usb_handle->primary, 0);
             libusb_close(usb_handle->primary);
         }
         if (usb_handle->boost) {
+            libusb_release_interface(usb_handle->boost, 0);
             libusb_close(usb_handle->boost);
         }
         delete usb_handle;


### PR DESCRIPTION
1. Release interfaces that may have been claimed before closing them, as per libusb documentation guidance.
2. Notify the threads to stop so that the destructor doesn't hang while streaming isn't in progress.