### PR TITLE
Rename shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ install(TARGETS librfnm_shared
 )
 
 set_target_properties(librfnm_shared PROPERTIES OUTPUT_NAME rfnm)
-set_target_properties(librfnm_static PROPERTIES OUTPUT_NAME rfnm)
+set_target_properties(librfnm_static PROPERTIES OUTPUT_NAME rfnm_static)
 
 #install(EXPORT librfnmTarget DESTINATION librfnm)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ install(TARGETS librfnm_shared
     BUNDLE DESTINATION bin COMPONENT Runtime
 )
 
-set_target_properties(librfnm_shared PROPERTIES OUTPUT_NAME rfnm)
+set_target_properties(librfnm_shared PROPERTIES OUTPUT_NAME rfnm_shared)
 set_target_properties(librfnm_static PROPERTIES OUTPUT_NAME rfnm)
 
 #install(EXPORT librfnmTarget DESTINATION librfnm)


### PR DESCRIPTION
This will rename the shared library to librfnm_shared.so under Linux and librfnm_shared.lib under Windows to prevent linkage issues under Windows