### PR TITLE
Don't install headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ target_link_libraries(librfnm PRIVATE spdlog)
 #set(DEST_DIR ${CMAKE_INSTALL_LIBDIR}/SoapySDR/modules${SOAPY_SDR_ABI_VERSION}/)
 
 #install(DIRECTORY include/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
-install(DIRECTORY include/librfnm DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+#install(DIRECTORY include/librfnm DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 
 #install(TARGETS librfnm


### PR DESCRIPTION
We're not installing anything from librfnm, it's a static library only meant to be built into other things. Any installed headers wouldn't have a corresponding library installed, and installed header versions may not match with available librfnm versions.