### PR TITLE
Implement channel alignment logic

### DIFF
--- a/include/librfnm/rx_stream.h
+++ b/include/librfnm/rx_stream.h
@@ -3,12 +3,6 @@
 #include "device.h"
 
 namespace rfnm {
-    struct partial_buf {
-        uint8_t* buf;
-        uint32_t left;
-        uint32_t offset;
-    };
-
     union quad_dc_offset {
         int8_t i8[8];
         int16_t i16[8];
@@ -29,7 +23,7 @@ namespace rfnm {
             size_t &elems_read, uint64_t &timestamp_ns, uint32_t timeout_us = 20000);
 
     private:
-        rfnm_api_failcode rx_dqbuf_multi(uint32_t timeout_us, bool dc_reset = false);
+        rfnm_api_failcode rx_dqbuf_multi(uint32_t timeout_us, bool first = false);
         void rx_qbuf_multi();
 
         device &dev;
@@ -39,10 +33,9 @@ namespace rfnm {
         bool stream_active = false;
 
         struct rx_buf * pending_rx_buf[MAX_RX_CHANNELS] = {};
+        uint32_t samples_left[MAX_RX_CHANNELS] = {};
 
-        struct partial_buf partial_rx_buf[MAX_RX_CHANNELS] = {};
-
-        int64_t sample_counter[MAX_RX_CHANNELS] = {};
+        int64_t sample_counter = 0;
         uint32_t last_phytimer[MAX_RX_CHANNELS] = {};
         double ns_per_sample;
         uint32_t phytimer_ticks_per_sample;

--- a/include/librfnm/rx_stream.h
+++ b/include/librfnm/rx_stream.h
@@ -42,7 +42,7 @@ namespace rfnm {
 
         struct partial_buf partial_rx_buf[MAX_RX_CHANNELS] = {};
 
-        uint64_t sample_counter[MAX_RX_CHANNELS] = {};
+        int64_t sample_counter[MAX_RX_CHANNELS] = {};
         uint32_t last_phytimer[MAX_RX_CHANNELS] = {};
         double ns_per_sample;
         uint32_t phytimer_ticks_per_sample;

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -168,8 +168,6 @@ MSDLL device::~device() {
         i.join();
     }
 
-    delete s;
-
     if (rx_buffers_allocated) {
         rx_flush();
 
@@ -181,6 +179,8 @@ MSDLL device::~device() {
             delete rxbuf;
         }
     }
+
+    delete s;
 
     if (usb_handle->primary) {
         libusb_release_interface(usb_handle->primary, 0);

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -169,7 +169,7 @@ MSDLL device::~device() {
     }
 
     if (rx_buffers_allocated) {
-        rx_flush();
+        rx_flush(0);
 
         // no need to take in_mutex as threads are finished
         while (rx_s.in.size()) {

--- a/src/rx_stream.cpp
+++ b/src/rx_stream.cpp
@@ -130,9 +130,10 @@ MSDLL rfnm_api_failcode rx_stream::start() {
             first_phytimer = lrxbuf->phytimer;
             first_phytimer_set = true;
         } else {
-            uint32_t rounding_ticks = phytimer_ticks_per_sample / 2;
-            uint32_t samp_delta = (lrxbuf->phytimer - first_phytimer + rounding_ticks) /
-                                  phytimer_ticks_per_sample;
+            int32_t rounding_ticks = phytimer_ticks_per_sample / 2;
+            int32_t samp_delta = static_cast<int32_t>(lrxbuf->phytimer - first_phytimer + rounding_ticks) /
+                                  static_cast<int32_t>(phytimer_ticks_per_sample);
+            spdlog::info("second channel delayed by {} samples", samp_delta);
             sample_counter[channel] = samp_delta;
         }
 

--- a/src/rx_stream.cpp
+++ b/src/rx_stream.cpp
@@ -296,7 +296,7 @@ rfnm_api_failcode rx_stream::rx_dqbuf_multi(uint32_t timeout_us, bool first) {
                 int32_t samp_delta = static_cast<int32_t>(pending_rx_buf[channel]->phytimer - first_phytimer + rounding_ticks) /
                                      static_cast<int32_t>(phytimer_ticks_per_sample);
                 //spdlog::info("second channel delayed by {} samples", samp_delta);
-                samples_left[channel] += samp_delta;
+                samples_left[channel] += 55; //samp_delta;
             }
         } else {
             int32_t samp_delta = static_cast<int32_t>(pending_rx_buf[channel]->phytimer - last_phytimer[channel] + rounding_ticks) /


### PR DESCRIPTION
Also eliminate unnecessary copying and fix a use-after-free bug. For now, the phytimer is unusable for channel synchronization (due to dequeue time being inconsistent relative to buffer start time), so I'm hard coding the second channel as starting 55 samples after the first. This is usually true, though sometimes it's off by 256 samples.