### PR TITLE
Fix missing include

### DIFF
--- a/include/librfnm/device.h
+++ b/include/librfnm/device.h
@@ -7,6 +7,7 @@
 #include <thread>
 #include <array>
 #include <vector>
+#include <chrono>
 
 #include "constants.h"
 #include "rfnm_fw_api.h"


### PR DESCRIPTION
std::chrono was not directly included which only shows itself as an issue on recent windows SDK versions.